### PR TITLE
feat: Maximize the SFX volume while fishing

### DIFF
--- a/InteractiveFishingBobber/InteractiveFishingBobber.lua
+++ b/InteractiveFishingBobber/InteractiveFishingBobber.lua
@@ -4,38 +4,45 @@ frame:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP");
 
 local originalArc = GetCVar("SoftTargetInteractArc");
 local originalRange = GetCVar("SoftTargetInteractRange");
-
+local originalSfxVolume = GetCVar("Sound_SFXVolume");
 
 local function eventHandler(self, event, unitTarget, castGUID, spellID)
 	if spellID ~= 131476 then return end
 	if unitTarget ~= "player" then return end
 
-
-	-- print ("Target - " .. unitTarget)
-
+	-- print("Target - " .. unitTarget)
 	-- print("Event - " .. event .. " - " .. spellID);
-	 if (event == "UNIT_SPELLCAST_CHANNEL_START") then
+
+	if (event == "UNIT_SPELLCAST_CHANNEL_START") then
 		-- print("Start - " .. event .. " - " .. spellID);
+
 		originalArc = GetCVar("SoftTargetInteractArc");
 		originalRange = GetCVar("SoftTargetInteractRange");
+		originalSfxVolume = GetCVar("Sound_SFXVolume");
 
 		-- print("Original Arc: " .. originalArc);
-		-- print("Original Range: " .. originalArc);
+		-- print("Original Range: " .. originalRange);
+		-- print("Original SFX Volume: " .. originalSfxVolume);
 
-		SetCVar( "SoftTargetInteractArc", 2 );
-		SetCVar( "SoftTargetInteractRange", 30 );
+		SetCVar("SoftTargetInteractArc", 2);
+		SetCVar("SoftTargetInteractRange", 30);
+		SetCVar("Sound_SFXVolume", 1);
+
 		-- print("Updated Arc: " .. 2);
 		-- print("Updated Range: " .. 30);
-
+		-- print("Updated SFX Volume: " .. 1);
 	end
 
 	if (event == "UNIT_SPELLCAST_CHANNEL_STOP") then
 		-- print("Stop - " .. event .. " - " .. spellID);
 		-- print("Resetting Arc to: " .. originalArc);
-		-- print("Resetting Arc to: " .. originalRange);
+		-- print("Resetting Range to: " .. originalRange);
+		-- print("Resetting SFX Volume to: " .. originalSfxVolume);
 
-		SetCVar( "SoftTargetInteractArc", originalArc );
-		SetCVar( "SoftTargetInteractRange", originalRange );
+		SetCVar("SoftTargetInteractArc", originalArc);
+		SetCVar("SoftTargetInteractRange", originalRange);
+		SetCVar("Sound_SFXVolume", originalSfxVolume);
 	end
 end
+
 frame:SetScript("OnEvent", eventHandler);

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-Improves interactivity of the fishing bobber for a better experience when using the interact key functionality introduced in 10.0 
+Improves interactivity of the fishing bobber for a better experience when using the interact key functionality introduced in 10.0
 
-This addon changes the `SoftTargetInteractArc` and `SoftTargetInteractRange` during the fishing cast. Changes are reset when you catch a fish or stop casting.
+This addon changes the `SoftTargetInteractArc`, `SoftTargetInteractRange`, and `Sound_SFXVolume` values during the fishing cast. Changes are reset when you catch a fish or stop casting.
 
 Changes the following values from their default (whatever you have set) to new values during the fishing cast:
+
 ```
 SoftTargetInteractArc: 2
 SoftTargetInteractRange: 30
+Sound_SFXVolume: 1
 ```


### PR DESCRIPTION
During the fishing channel, set SFX Volume to 1, the maximum. After the channel ends, reset SFX Volume to its original value.